### PR TITLE
Update node.yaml to support graphdriver: overlay

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -44,7 +44,7 @@ coreos:
         [Service]
         EnvironmentFile=/run/flannel/subnet.env
         ExecStartPre=/bin/mount --make-rprivate /
-        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=btrfs -H fd://
+        ExecStart=/usr/bin/docker -d --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} -s=overlay -H fd://
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
Update node.yaml to support graphdriver: overlay as btrfs produces "fatal" "prerequisites for driver not satisfied (wrong filesystem?)" on CoreOS Alpha 561.0.0